### PR TITLE
header: Add links to symbiflow website and documentation

### DIFF
--- a/sphinx_symbiflow_theme/header.html
+++ b/sphinx_symbiflow_theme/header.html
@@ -40,6 +40,16 @@
               </a>
           {%- endif -%}
       {%- endfor %}
+      {% if not theme_hide_symbiflow_links %}
+          <a  class="mdl-navigation__link" href="https://symbiflow.github.io/">
+            <i class="material-icons navigation-link-icon">launch</i>
+            SymbiFlow Website
+          </a>
+          <a  class="mdl-navigation__link" href="https://symbiflow.readthedocs.io/en/latest/">
+            <i class="material-icons navigation-link-icon">launch</i>
+            SymbiFlow Docs
+          </a>
+      {%- endif -%}
       </nav>
     </div>
 </header>

--- a/sphinx_symbiflow_theme/header.html
+++ b/sphinx_symbiflow_theme/header.html
@@ -40,13 +40,13 @@
               </a>
           {%- endif -%}
       {%- endfor %}
-      {% if not theme_hide_symbiflow_links %}
+      {% if not theme_hide_symbiflow_links|tobool %}
           <a  class="mdl-navigation__link" href="https://symbiflow.github.io/">
-            <i class="material-icons navigation-link-icon">launch</i>
+            <i class="material-icons navigation-link-icon">web</i>
             SymbiFlow Website
           </a>
           <a  class="mdl-navigation__link" href="https://symbiflow.readthedocs.io/en/latest/">
-            <i class="material-icons navigation-link-icon">launch</i>
+            <i class="material-icons navigation-link-icon">library_books</i>
             SymbiFlow Docs
           </a>
       {%- endif -%}

--- a/sphinx_symbiflow_theme/theme.conf
+++ b/sphinx_symbiflow_theme/theme.conf
@@ -19,3 +19,5 @@ header_scroll = False
 show_header_title = False
 show_drawer_title = True
 show_footer = True
+
+hide_symbiflow_links = False


### PR DESCRIPTION
Any documentation that uses this theme will have these 2 links in the header by default. The option `'hide_symbiflow_links'` in `html_theme_options` can be set to `True` in conf.py to disable this feature.

![image](https://user-images.githubusercontent.com/8130120/81033486-77a21080-8ec6-11ea-87d9-20eb4dd5050e.png)

Should resolve SymbiFlow/fasm#26

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>