### PR TITLE
Fix align center option for images

### DIFF
--- a/src/scss/_root.scss
+++ b/src/scss/_root.scss
@@ -93,10 +93,11 @@ table.highlighttable {
 /*
  * Basic style alignment
  */
-
-.align-center {
+ .align-center {
     margin-left: auto !important;
     margin-right: auto !important;
+    display: block;
+    text-align: center;
 }
 
 .align-default {


### PR DESCRIPTION
Add css so that `:align: center;` works for `.. image` and `.. figure`.

Resolve #9 

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>